### PR TITLE
滚动时正确触发组件传入的 batch 值更新, 以触发 batch 监听

### DIFF
--- a/src/utils/viewport-change-func.js
+++ b/src/utils/viewport-change-func.js
@@ -28,7 +28,9 @@ module.exports = function (e, cb) {
   }
   obj[item.key] = newList
   const comp = this.selectComponent('#' + detail.id)
-  obj[comp.data.batchKey] = !this.data.batchSetRecycleData
+  // obj[comp.data.batchKey] = !this.data.batchSetRecycleData
+  // Fix 触发batch监听 重新设置scrollTop值等 (触发 _recycleInnerBatchDataChanged 函数)
+  obj[comp.data.batchKey] = !comp.data.batch
   comp._setInnerBeforeAndAfterHeight({
     beforeHeight: pos.minTop,
     afterHeight: pos.afterHeight


### PR DESCRIPTION
此前的 "obj[comp.data.batchKey] = !this.data.batchSetRecycleData" 中的 batchSetRecycleData 是组件传入自定义的 batch-key 不应写死