### PR TITLE
修复sizeMap不能正确找到最大值

### DIFF
--- a/src/recycle-view.js
+++ b/src/recycle-view.js
@@ -329,7 +329,7 @@ Component({
       let endIndex
       const sizeMap = this.sizeMap
       for (let i = startLine; i <= endLine; i++) {
-        for (let col = 0; col < rectEachLine; col++) {
+        for (let col = 0; col <= rectEachLine; col++) {
           const key = `${i}.${col}`
           // 找到sizeMap里面的最小值和最大值即可
           if (!sizeMap[key]) continue


### PR DESCRIPTION
sizeMap 的 key 结构是 0.0 0.1 1.0 1.1 时 for (let col = 0; col < rectEachLine; col++) 不能正确遍历到所有key值