### PR TITLE
修复页面多个recycle-view时 传入 自定义的不同 batch-key 不能正确生效等问题

### DIFF
--- a/src/recycle-view.js
+++ b/src/recycle-view.js
@@ -329,7 +329,7 @@ Component({
       let endIndex
       const sizeMap = this.sizeMap
       for (let i = startLine; i <= endLine; i++) {
-        for (let col = 0; col < rectEachLine; col++) {
+        for (let col = 0; col <= rectEachLine; col++) {
           const key = `${i}.${col}`
           // 找到sizeMap里面的最小值和最大值即可
           if (!sizeMap[key]) continue

--- a/src/recycle-view.js
+++ b/src/recycle-view.js
@@ -125,7 +125,22 @@ Component({
       type: Number,
       public: true,
       value: DEFAULT_SHOW_SCREENS
-    }
+    },
+    // 以下是自定义组件下拉刷新属性
+    "refresherEnabled": Boolean,
+    "refresherThreshold": {
+      type: Number,
+      value: 45
+    },
+    "refresherDefaultStyle": {
+      type: String,
+      value: 'black'
+    },
+    "refresherBackground": {
+      type: String,
+      value: '#FFF'
+    },
+    "refresherTriggered": Boolean
   },
 
   /**
@@ -192,6 +207,9 @@ Component({
     },
     _scrollToLower(e) {
       this.triggerEvent('scrolltolower', e.detail)
+    },
+    _refresherrefresh(e) {
+      this.triggerEvent('refresherrefresh', e.detail);
     },
     _beginToScroll() {
       if (!this._lastScrollTop) {

--- a/src/recycle-view.wxml
+++ b/src/recycle-view.wxml
@@ -1,6 +1,32 @@
 <!--components/recycle-view/recycle-view.wxml-->
-<view bindtouchstart='_beginToScroll' style="height:{{useInPage ? totalHeight + (hasBeforeSlotHeight ? beforeSlotHeight : 0) + (hasAfterSlotHeight ? afterSlotHeight : 0) : height}}px;width:{{width}}px;transform:translateZ(0);-webkit-transform:translateZ(0);" id="content" class="wrap">
-  <scroll-view bindscroll="_scrollViewDidScroll" class="content" style='height:100%;position: relative;' scroll-y="{{useInPage ? false : scrollY}}" scroll-x="{{false}}" upper-threshold="{{upperThreshold}}" lower-threshold="{{lowerThreshold}}" scroll-top="{{innerScrollTop}}" scroll-into-view="{{innerScrollIntoView}}" scroll-with-animation="{{scrollWithAnimation}}" bindscrolltoupper="_scrollToUpper" bindscrolltolower="_scrollToLower" scroll-anchoring enable-back-to-top="{{enableBackToTop}}" throttle="{{throttle}}">
+<view
+  bindtouchstart='_beginToScroll'
+  style="height:{{useInPage ? totalHeight + (hasBeforeSlotHeight ? beforeSlotHeight : 0) + (hasAfterSlotHeight ? afterSlotHeight : 0) : height}}px;width:{{width}}px;transform:translateZ(0);-webkit-transform:translateZ(0);"
+  id="content"
+  class="wrap"
+>
+  <scroll-view
+    scroll-y="{{useInPage ? false : scrollY}}"
+    upper-threshold="{{upperThreshold}}"
+    lower-threshold="{{lowerThreshold}}"
+    scroll-top="{{innerScrollTop}}"
+    scroll-into-view="{{innerScrollIntoView}}"
+    scroll-with-animation="{{scrollWithAnimation}}"
+    enable-back-to-top="{{enableBackToTop}}"
+    scroll-anchoring
+    refresher-enabled="{{!!refresherEnabled}}"
+    refresher-default-style="{{refresherDefaultStyle}}"
+    refresher-background="{{refresherBackground}}"
+    refresher-triggered="{{!!refresherTriggered}}"
+    refresher-threshold="{{refresherThreshold}}"
+    bindrefresherrefresh="_refresherrefresh"
+    bindscroll="_scrollViewDidScroll"
+    class="content"
+    style='height:100%;position: relative;'
+    bindscrolltoupper="_scrollToUpper"
+    bindscrolltolower="_scrollToLower"
+    throttle="{{throttle}}"
+  >
     <view style="position: absolute;z-index:1;width:100%;left: 0;top: 0;opacity: 0;visibility: hidden;">
       <slot name="itemsize"></slot>
     </view>

--- a/src/utils/viewport-change-func.js
+++ b/src/utils/viewport-change-func.js
@@ -28,7 +28,8 @@ module.exports = function (e, cb) {
   }
   obj[item.key] = newList
   const comp = this.selectComponent('#' + detail.id)
-  obj[comp.data.batchKey] = !this.data.batchSetRecycleData
+  // obj[comp.data.batchKey] = !this.data.batchSetRecycleData
+  obj[comp.data.batchKey] = !comp.data.batch
   comp._setInnerBeforeAndAfterHeight({
     beforeHeight: pos.minTop,
     afterHeight: pos.afterHeight


### PR DESCRIPTION
1、经测试 sizeMap并不能每次都获取到正确的最大值 `col < rectEachLine` 更改为 `col <= rectEachLine`
2、同一页面使用多个recycle-view时 自定义 batch-key 不能正确触发监听 batch `obj[comp.data.batchKey] = !this.data.batchSetRecycleData` 更改为 `obj[comp.data.batchKey] = !comp.data.batch`
3、新增下拉刷新功能 API 已暴露给用户自定义